### PR TITLE
Fix cleanText regex for dashboard init

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,6 +333,7 @@
         let radarChart = null;
         let isProcessing = false;
         let scanController = null; // For cancelling requests
+        let currentSaved = [];
 
         const MISSION_EMOJIS = { 'A Fairer Start': '📚', 'A Healthy Life': '❤️‍🩹', 'A Sustainable Future': '🌳' };
         const LENS_EMOJIS = { 'Social': '👥', 'Tech': '🤖', 'Media': '🎙️', 'Powerhouse': '⚡' };
@@ -356,9 +357,8 @@
             if (!text) return "";
             // Remove "In 2024," or "In 2025 " at the start
             let clean = text.replace(/^In \d{4},?\s*/i, "");
-            // Remove citations like
-            // We use a regex that looks for
-            clean = clean.replace(/\/g, "");
+            // Drop bracketed citations (e.g. "[1]") and stray backslashes
+            clean = clean.replace(/\[[^\]]*\]/g, "").replace(/\\/g, "");
             return clean;
         }
 

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from typing import Optional, List, Dict, Any, Set
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from openai import OpenAI
 from dotenv import load_dotenv
 import gspread
@@ -190,7 +190,7 @@ async def perform_google_search(query, date_restrict="m1", requested_results: in
 class ChatRequest(BaseModel):
     message: str
     time_filter: str = "Past Month"
-    source_types: List[str] = []
+    source_types: List[str] = Field(default_factory=list)
     tech_mode: bool = False
 
 @app.post("/api/chat")
@@ -282,8 +282,10 @@ async def chat_endpoint(req: ChatRequest):
         print(f"Server Error: {e}")
         # Only check for cancellation if 'run' was created
         if isinstance(e, asyncio.CancelledError) and run:
-             try: await asyncio.to_thread(client.beta.threads.runs.cancel, thread_id=run.thread_id, run_id=run.id)
-             except: pass
+            try:
+                await asyncio.to_thread(client.beta.threads.runs.cancel, thread_id=run.thread_id, run_id=run.id)
+            except Exception:
+                pass
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/api/saved")


### PR DESCRIPTION
## Summary
- correct the cleanText regex to remove bracketed citations and stray backslashes without causing syntax errors
- ensure dashboard initialization runs by letting scripts parse fully

## Testing
- python -m compileall main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6942d900674083329a264077f414e123)